### PR TITLE
Add black code formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# See https://pre-commit.com/
+# See https://github.com/psf/black#version-control-integration
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.6

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # IOEngine
+
+## Development
+
+- Install the packages needed for development.
+
+  ```
+  pip install -r requirements_dev.txt
+  ```
+
+- Run `tox` to test and lint the code.
+
+  ```
+  tox
+  ```
+
+- We use black code formatter to format the code automatically.
+
+  ```
+  black ./
+  ```

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,8 @@
+[MASTER]
+reports=no
+
+# Black needs to disable wrong-hanging-indent.
+
+disable=
+  bad-continuation,
+  locally-disabled,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+-r requirements_lint.txt
+-r requirements_test.txt
+tox==3.14.0
+
+-e .

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,3 +1,4 @@
+black==19.3b0
 flake8==3.7.8
 pydocstyle==4.0.1
 pylint==2.4.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88
+
+[pydocstyle]
+add-ignore = D202
+
+[flake8]
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
 basepython = python3
 ignore_errors = True
 commands =
+  black --check ./
   flake8 ioengine tests
   pylint ioengine tests
   pydocstyle ioengine tests


### PR DESCRIPTION
- Add config to make lint compatible with black.
- Add tox config to run black on tox lint env.
- Provide a pre-commit-config for developers that want to use pre-commit.
- Add a requirements file for developers to install all development dependencies.
- Update readme with development instructions.